### PR TITLE
Fix two issues that effected package publishing

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -107,6 +107,7 @@ class GoogleCloudStorageHandler implements IPackageStorageManager {
       file
         .delete()
         .then((): void => {
+          GoogleCloudStorageHandler.packageJsonCache = {}; // clear the package.json cache
           this.logger.debug({ name: file.name }, 'gcloud: @{name} was deleted successfully from storage');
           cb(null);
         })
@@ -131,6 +132,7 @@ class GoogleCloudStorageHandler implements IPackageStorageManager {
     this.logger.debug({ name: file.name }, 'gcloud: removing the package @{name} from storage');
     file.delete().then(
       (): void => {
+        GoogleCloudStorageHandler.packageJsonCache = {}; // clear the package.json cache
         this.logger.debug({ name: file.name }, 'gcloud: package @{name} was deleted successfully from storage');
         callback(null);
       },
@@ -167,6 +169,7 @@ class GoogleCloudStorageHandler implements IPackageStorageManager {
     this.logger.debug({ name }, 'gcloud: saving package for @{name}');
     this._savePackage(name, value)
       .then((): void => {
+        GoogleCloudStorageHandler.packageJsonCache = {}; // clear the package.json cache
         this.logger.debug({ name }, 'gcloud: @{name} has been saved successfully on storage');
         cb(null);
       })
@@ -230,7 +233,7 @@ class GoogleCloudStorageHandler implements IPackageStorageManager {
 
     const cachedPackageJson = GoogleCloudStorageHandler.packageJsonCache[packageName];
     if (cachedPackageJson && cachedPackageJson.timestamp > new Date().getTime() - (PACKAGE_CACHE_TTL_SECONDS * 1000)) {
-      const { content } = await cachedPackageJson;
+      const content = await cachedPackageJson.content;
       const packageJson: Package = JSON.parse(content[0].toString('utf8'));
       this.logger.info(`gcloud: [_readPackage] providing '${PACKAGE_JSON}' file for package '${packageName}' from CACHE`);
       return packageJson;


### PR DESCRIPTION
Closes #10 

This PR fixes two issues related to package publishing:
1. When publishing a package, the final operation of the process was to retrieve the latest `package.json` for the package. This would result in a 404 since the `package.json` would be pulled from the cache and wasn't up-to-date. This was a side effect of verdaccio looking for the the latest version information inside the `package.json` that was just saved for the published version but it was not present due to the cached `package.json` being returned. This was fixed by clearing the `package.json` cache on any write/delete operation.
2. A object destructuring error resulted in the containing cache object being `await`ed instead of the `content` Promise inside the cache object.